### PR TITLE
Disabled joint verse feature for 1st verse

### DIFF
--- a/src/components/Content/Translation/TranslationPanel.js
+++ b/src/components/Content/Translation/TranslationPanel.js
@@ -105,7 +105,13 @@ const TranslationPanel = (props) => {
                             : false
                         }
                         style={{ outline: "none" }}
-                        onContextMenu={(event) => handleJoint(event, index)}
+                        onContextMenu={
+                          index !== 0
+                            ? (event) => {
+                                handleJoint(event, index);
+                              }
+                            : false
+                        }
                         suppressContentEditableWarning={true}
                         primary={
                           AutographaStore.jointVerse[index] === undefined


### PR DESCRIPTION
The 1st verse of every chapter can't be joined with the last verse of the previous chapter, technically this is wrong, so the Joint verse feature is been disabled for the 1st verse. #31  