### PR TITLE
#377: Login page > focus signin button on tab, show outline

### DIFF
--- a/renderer/src/components/Login/CustomLogin.js
+++ b/renderer/src/components/Login/CustomLogin.js
@@ -96,6 +96,7 @@ const CustomLogin = ({
         value={buttonname}
         className="text-xs
            focus:border-blue-600
+           focus:ring
            max-w-md h-12 appearance-none
            cursor-pointer
            border rounded

--- a/renderer/src/components/Login/Login.js
+++ b/renderer/src/components/Login/Login.js
@@ -212,10 +212,10 @@ export default function Login() {
           </div>
 
           <div className="absolute bottom-4 left-0 right-0 flex items-center justify-center gap-5 bg-white text-black font-bold">
-            <a href="/">EN(US)</a>
-            <a href="/">ABOUT</a>
-            <a href="/">PRIVACY</a>
-            <a href="/">TERMS</a>
+            <a href="/" onClick={(event) => event.preventDefault()}>EN(US)</a>
+            <a href="/" onClick={(event) => event.preventDefault()}>ABOUT</a>
+            <a href="/" onClick={(event) => event.preventDefault()}>PRIVACY</a>
+            <a href="/" onClick={(event) => event.preventDefault()}>TERMS</a>
           </div>
         </div>
 


### PR DESCRIPTION
#377 On the login page when clicking tab show the outline on the Sign In button
#379 Login page disable click for links on bottom of page