### PR TITLE
issue 454 related to Scope-Bible navigation

### DIFF
--- a/renderer/src/components/EditorPage/Navigation/CustomNavigation.js
+++ b/renderer/src/components/EditorPage/Navigation/CustomNavigation.js
@@ -66,6 +66,7 @@ export default function CustomNavigation({
   }
 
   function openBooks() {
+    setSelectedBooks([(bookId.toUpperCase())]);
     setOpenBook(true);
   }
 
@@ -162,6 +163,10 @@ export default function CustomNavigation({
                 multiSelectBook={multiSelectBook}
                 selectedBooks={selectedBooks}
                 setSelectedBooks={setSelectedBooks}
+                // The SelectBook is also been used to set the Canon-Scope for the projects and
+                // "scope" is added to disable the click on the book list. scope="Other" will only
+                // allow to click/select the book.
+                scope="Other"
               >
                 <button
                   type="button"

--- a/renderer/src/components/EditorPage/Navigation/reference/SelectBook.js
+++ b/renderer/src/components/EditorPage/Navigation/reference/SelectBook.js
@@ -15,6 +15,7 @@ export default function SelectBook({
   multiSelectBook,
   selectedBooks,
   setSelectedBooks,
+  scope,
  }) {
   const [openNT, setOpenNT] = useState(true);
   const [openOT, setOpenOT] = useState(true);
@@ -53,63 +54,26 @@ export default function SelectBook({
     }
   }
   React.useEffect(() => {
-    if (selectedBooks.length === 39) {
+    if (scope === 'Old Testament (OT)') {
       toggleOT();
-    } else if (selectedBooks.length === 27) {
+    } else if (scope === 'New Testament (NT)') {
       toggleNT();
     } else {
       toggle();
     }
-  }, [selectedBooks]);
+  }, [scope]);
   return (
     <>
       <div className="flex flex-row text-center bg-gray-800 text-white text-sm font-bold tracking-wide uppercase">
         <div className="w-40 m-auto grid grid-cols-3 gap-0 bg-primary">
           <div onClick={toggle} className="p-2 bg-black hover:bg-primary backdrop-opacity-20 cursor-pointer">All</div>
-          <div onClick={toggleNT} className={openNT === false ? 'p-2 bg-black hover:bg-primary backdrop-opacity-20 cursor-pointer' : 'p-2 border-r-2 border-black hover:bg-black border-opacity-5 cursor-pointer'}>NT</div>
           <div onClick={toggleOT} className={openOT === false ? 'p-2 bg-black hover:bg-primary backdrop-opacity-20 cursor-pointer' : 'p-2 border-r-2 border-black hover:bg-black border-opacity-5 cursor-pointer'}>OT</div>
+          <div onClick={toggleNT} className={openNT === false ? 'p-2 bg-black hover:bg-primary backdrop-opacity-20 cursor-pointer' : 'p-2 border-r-2 border-black hover:bg-black border-opacity-5 cursor-pointer'}>NT</div>
         </div>
         <div className="flex justify-end">
           {children}
         </div>
       </div>
-
-      <Disclosure>
-        {openNT && (
-          <>
-            <div className="p-2 text-center bg-gray-200 text-gray-700 text-xs font-semibold tracking-wide uppercase cursor-pointer">
-              new testament
-            </div>
-            <Transition
-              show={openNT}
-              enter="transition duration-100 ease-out"
-              enterFrom="transform scale-95 opacity-0"
-              enterTo="transform scale-100 opacity-100"
-              leave="transition duration-75 ease-out"
-              leaveFrom="transform scale-100 opacity-100"
-              leaveTo="transform scale-95 opacity-0"
-            >
-              <Disclosure.Panel static>
-                <div className="bg-white grid grid-cols-4 gap-1 p-4 text-xxs text-left font-bold tracking-wide uppercase">
-                  {bookList.map((book, index) => (index > 38 && (
-                  <div
-                    key={book.name}
-                    onClick={(e) => (multiSelectBook
-                    ? selectMultipleBooks(e, book.key, book.name)
-                    : bookSelect(e, book.key, book.name))}
-                    className={`${styles.select} ${selectedBooks.includes((book.key).toUpperCase()) ? styles.active : ''}`}
-                  >
-                    {book.name}
-                  </div>
-                    )
-                  ))}
-                </div>
-              </Disclosure.Panel>
-            </Transition>
-          </>
-        )}
-
-      </Disclosure>
 
       <Disclosure>
         {openOT && (
@@ -127,7 +91,7 @@ export default function SelectBook({
               leaveTo="transform scale-95 opacity-0"
             >
               <Disclosure.Panel static>
-                <div className="bg-white grid grid-cols-4 gap-1 p-4 text-xxs text-left font-bold tracking-wide uppercase">
+                <div className="bg-white grid grid-cols-4 gap-1 p-4 text-xxs text-left font-bold tracking-wide uppercase" style={{ pointerEvents: scope !== 'Other' ? 'none' : 'auto' }}>
                   {bookList.map((book, index) => (
                       index <= 38 && (
                         <div
@@ -149,6 +113,42 @@ export default function SelectBook({
         )}
 
       </Disclosure>
+      <Disclosure>
+        {openNT && (
+          <>
+            <div className="p-2 text-center bg-gray-200 text-gray-700 text-xs font-semibold tracking-wide uppercase cursor-pointer">
+              new testament
+            </div>
+            <Transition
+              show={openNT}
+              enter="transition duration-100 ease-out"
+              enterFrom="transform scale-95 opacity-0"
+              enterTo="transform scale-100 opacity-100"
+              leave="transition duration-75 ease-out"
+              leaveFrom="transform scale-100 opacity-100"
+              leaveTo="transform scale-95 opacity-0"
+            >
+              <Disclosure.Panel static>
+                <div className="bg-white grid grid-cols-4 gap-1 p-4 text-xxs text-left font-bold tracking-wide uppercase" style={{ pointerEvents: scope !== 'Other' ? 'none' : 'auto' }}>
+                  {bookList.map((book, index) => (index > 38 && (
+                  <div
+                    key={book.name}
+                    onClick={(e) => (multiSelectBook
+                    ? selectMultipleBooks(e, book.key, book.name)
+                    : bookSelect(e, book.key, book.name))}
+                    className={`${styles.select} ${selectedBooks.includes((book.key).toUpperCase()) ? styles.active : ''}`}
+                  >
+                    {book.name}
+                  </div>
+                    )
+                  ))}
+                </div>
+              </Disclosure.Panel>
+            </Transition>
+          </>
+        )}
+
+      </Disclosure>
     </>
   );
 }
@@ -161,4 +161,5 @@ SelectBook.propTypes = {
   selectedBooks: PropTypes.array,
   multiSelectBook: PropTypes.bool,
   setSelectedBooks: PropTypes.func,
+  scope: PropTypes.string,
 };

--- a/renderer/src/components/ProjectsPage/CreateProject/AdvancedSettingsDropdown.js
+++ b/renderer/src/components/ProjectsPage/CreateProject/AdvancedSettingsDropdown.js
@@ -51,6 +51,7 @@ export default function AdvancedSettingsDropdown({ call, project }) {
   const [isShow, setIsShow] = React.useState(true);
   const [bibleNav, setBibleNav] = React.useState(false);
   const [handleNav, setHandleNav] = React.useState();
+  const [currentScope, setCurrentScope] = React.useState();
   const handleClick = () => {
     setIsShow(!isShow);
   };
@@ -67,26 +68,32 @@ export default function AdvancedSettingsDropdown({ call, project }) {
       if (Object.keys(project.type.flavorType.currentScope).length === 66) {
         const vals = Object.keys(project.type.flavorType.currentScope).map((key) => key);
         setcanonSpecification({ title: 'All Books', currentScope: vals });
+        setCurrentScope({ title: 'All Books', currentScope: vals });
       } else {
         const vals = Object.keys(project.type.flavorType.currentScope).map((key) => key);
         setcanonSpecification({ title: 'Other', currentScope: vals });
+        setCurrentScope({ title: 'Other', currentScope: vals });
       }
     } else if ((project.type.flavorType.canonType).length === 1) {
       if (project.type.flavorType.canonType[0] === 'ot') {
         if (Object.keys(project.type.flavorType.currentScope).length === 39) {
           const vals = Object.keys(project.type.flavorType.currentScope).map((key) => key);
           setcanonSpecification({ title: 'Old Testament (OT)', currentScope: vals });
+          setCurrentScope({ title: 'Old Testament (OT)', currentScope: vals });
         } else {
           const vals = Object.keys(project.type.flavorType.currentScope).map((key) => key);
           setcanonSpecification({ title: 'Other', currentScope: vals });
+          setCurrentScope({ title: 'Other', currentScope: vals });
         }
       } else if (project.type.flavorType.canonType[0] === 'nt') {
         if (Object.keys(project.type.flavorType.currentScope).length === 27) {
           const vals = Object.keys(project.type.flavorType.currentScope).map((key) => key);
           setcanonSpecification({ title: 'New Testament (NT)', currentScope: vals });
+          setCurrentScope({ title: 'New Testament (NT)', currentScope: vals });
         } else {
           const vals = Object.keys(project.type.flavorType.currentScope).map((key) => key);
           setcanonSpecification({ title: 'Other', currentScope: vals });
+          setCurrentScope({ title: 'Other', currentScope: vals });
         }
       }
     }
@@ -108,7 +115,17 @@ export default function AdvancedSettingsDropdown({ call, project }) {
     }
     setCopyRight(myLicence);
   };
-  const selectCanon = (value) => {
+  const selectCanon = (val) => {
+    const value = val;
+    if (call === 'edit' && value.title === 'Other') {
+      if (canonSpecification.title === 'Other') {
+        value.currentScope = canonSpecification.currentScope;
+      } else {
+       value.currentScope = currentScope.currentScope;
+      }
+    } else if (canonSpecification.title === 'Other' && value.title === 'Other') {
+        value.currentScope = canonSpecification.currentScope;
+      }
     setcanonSpecification(value);
     openBibleNav('edit');
   };

--- a/renderer/src/components/ProjectsPage/CreateProject/CustomCanonSpecification.js
+++ b/renderer/src/components/ProjectsPage/CreateProject/CustomCanonSpecification.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React, { Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { XIcon } from '@heroicons/react/solid';
@@ -63,7 +64,7 @@ const CustomCanonSpecification = ({ bibleNav, closeBibleNav, handleNav }) => {
         <Dialog.Overlay className="fixed inset-0 bg-black opacity-30" />
         <div className="flex items-center justify-center h-screen ">
           <div className="w-5/12 m-auto z-50 bg-white shadow overflow-hidden sm:rounded-lg">
-            <div className="p-3">
+            {/* <div className="p-3">
               <input
                 type="text"
                 name="new spec"
@@ -73,12 +74,13 @@ const CustomCanonSpecification = ({ bibleNav, closeBibleNav, handleNav }) => {
                 disabled
                 className="bg-white w-80 block rounded shadow-sm sm:text-sm focus:ring-gray-500 focus:border-primary border-gray-300"
               />
-            </div>
+            </div> */}
             <SelectBook
               bookList={bookList}
               multiSelectBook
               selectedBooks={selectedBooks}
               setSelectedBooks={setSelectedBooks}
+              scope={name}
             >
               <button
                 type="button"

--- a/renderer/src/modules/biblenavigation/BibleNavigation.js
+++ b/renderer/src/modules/biblenavigation/BibleNavigation.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import PropTypes from 'prop-types';
 import { Dialog, Transition } from '@headlessui/react';
 import {
@@ -65,6 +64,7 @@ export default function BibleNavigation(props) {
   }
 
   function openBooks() {
+    setSelectedBooks([(bookId.toUpperCase())]);
     setOpenBook(true);
   }
 
@@ -175,6 +175,10 @@ export default function BibleNavigation(props) {
                 multiSelectBook={multiSelectBook}
                 selectedBooks={selectedBooks}
                 setSelectedBooks={setSelectedBooks}
+                // The SelectBook is also been used to set the Canon-Scope for the projects and
+                // "scope" is added to disable the click on the book list. scope="Other" will only
+                // allow to click/select the book.
+                scope="Other"
               >
                 <button
                   type="button"


### PR DESCRIPTION
Fixed issue #454 
1. Displaying the Actual list in the custom scope.
2. Disabled click/select for the scopes other than Custom.
3. While solving the 2nd issue, it broke the navigation on the Editor page, FIXED IT.
4. Removed the extra displaying title from the Bible navigation i.e. displaying **Other** in the below screenshot.

![Screenshot from 2022-03-14 13-51-36](https://user-images.githubusercontent.com/37212471/158132785-8f9d2e68-d5e5-45f7-bad3-b984ae2348f8.png)

