### PR TITLE
Fix missing entry point file error

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,15 @@
   "build": {
     "asar": true,
     "extraResources": "renderer/public",
+    "extraMetadata": {
+      "main": "main/index.js"
+    },
     "files": [
       "main",
       "renderer/out",
       "public",
       "renderer/public/**/*",
       "build/**/*",
-      "main",
       "postcss.config.js",
       "renderer/jsconfig.json",
       "styles/**/*"
@@ -176,7 +178,8 @@
     "webpack-node-externals": "^3.0.0",
     "winston": "^3.7.2",
     "word-aligner": "^1.0.0",
-    "ws": "^8.8.0"
+    "ws": "^8.8.0",
+    "yarn": "^1.22.19"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.6",


### PR DESCRIPTION
## Background
The build was breaking complaining about a missing entry point file.

## Fix
This PR fixes the failing build (only tested on Ubuntu) by explicitly setting the entry point file. See https://github.com/electron-userland/electron-builder/issues/2404#issuecomment-1243608565 for more details.
