### PR TITLE
placeholder text for usfmversification

### DIFF
--- a/renderer/src/util/createVersificationUSFM.js
+++ b/renderer/src/util/createVersificationUSFM.js
@@ -73,7 +73,7 @@ export const createVersificationUSFM = (
                   verses.push({
                     verseNumber: i.toString(),
                     verseText: '',
-                    // contents: [],
+                    contents: [ "..."], // adding default text to verses to mitigate the empty verse bug
                   });
                 }
                 contents = contents.concat(verses);


### PR DESCRIPTION
Have added a placeholder text `...` (three dots) that results in users being able to add text to newly created usfm files. The edge case bugs are still there. But this mitigates the newly added text disappearing issue to the most part.
Every new usfm file that is created in the app will have this placeholder text for every verse. 